### PR TITLE
updated change method to return args

### DIFF
--- a/colorpicker.js
+++ b/colorpicker.js
@@ -82,7 +82,7 @@
 				setSelector(col, cal.get(0));
 				setHue(col, cal.get(0));
 				setNewColor(col, cal.get(0));
-				cal.data('colorpicker').onChange.apply(cal, [col, HSBToHex(col), HSBToRGB(col)]);
+				cal.data('colorpicker').onChange.apply(cal, [col, HSBToHex(col), HSBToRGB(col),  cal.data('colorpicker').parent ]);
 			},
 			blur = function (ev) {
 				var cal = $(this).parent().parent();


### PR DESCRIPTION
Made a change so that the onChange now provides an additional param of the element, similar to select, making it possible to do a live color select using the actual element instead of relying on a dom request.

ie.
 
$('.colorSelector').ColorPicker({
  onChange : function(hsb, hex, rgb, el) {
     $(el).find('div').css('backgroundColor', '#' + hex);
     $(el).val(hex);
     $(el).data( hex );
  }
});
